### PR TITLE
Add foreground service types to avoid crashing on Android 14 devices

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
 
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="29"/>
@@ -31,6 +32,11 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="dataSync"
+            tools:node="merge" />
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/kotlin/com/sanmer/mrepo/works/DownloadWork.kt
+++ b/app/src/main/kotlin/com/sanmer/mrepo/works/DownloadWork.kt
@@ -1,6 +1,8 @@
 package com.sanmer.mrepo.works
 
 import android.content.Context
+import android.content.pm.ServiceInfo
+import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.net.toUri
 import androidx.hilt.work.HiltWorker
@@ -132,7 +134,15 @@ class DownloadWork @AssistedInject constructor(
             .apply { title?.let { setContentTitle(it) } }
             .build()
 
-        return ForegroundInfo(id.version(), notification)
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ForegroundInfo(
+                id.version(),
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+            )
+        } else {
+            ForegroundInfo(id.version(), notification)
+        }
     }
 
     private fun notifyFinish(title: String, message: String, silent: Boolean): ForegroundInfo {
@@ -144,7 +154,15 @@ class DownloadWork @AssistedInject constructor(
             .setSilent(silent)
             .build()
 
-        return ForegroundInfo(id.version() + 1, notification)
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ForegroundInfo(
+                id.version(),
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+            )
+        } else {
+            ForegroundInfo(id.version(), notification)
+        }
     }
 
     @Suppress("unused")


### PR DESCRIPTION
See behavior changes in Android 14: https://developer.android.com/about/versions/14/behavior-changes-14

Foreground service types are required: https://developer.android.com/about/versions/14/changes/fgs-types-required

